### PR TITLE
Preview XCode failed

### DIFF
--- a/Sources/Camera-SwiftUI/View/CameraPreview.swift
+++ b/Sources/Camera-SwiftUI/View/CameraPreview.swift
@@ -37,7 +37,7 @@ public struct CameraPreview: UIViewRepresentable {
             self.focusView.layer.frame = CGRect(origin: layerPoint, size: CGSize(width: 50, height: 50))
             
             
-            NotificationCenter.default.post(.init(name: .init("UserDidRequestNewFocusPoint"), object: nil, userInfo: ["devicePoint": devicePoint]))
+            NotificationCenter.default.post(.init(name: .init("UserDidRequestNewFocusPoint"), object: nil, userInfo: ["devicePoint": devicePoint] as [AnyHashable: Any]))
             
             UIView.animate(withDuration: 0.3, animations: {
                 self.focusView.layer.opacity = 1


### PR DESCRIPTION
Correction of compiling failed: cannot convert value of type 'OSLogMessage' to expected dictionary key type 'AnyHashable' of Preview Xcode