### PR TITLE
Allow overriding video gravity

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Camera-SwiftUI",
-            dependencies: []),
+            dependencies: [],
+            resources: [.copy("Resources/PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "Camera-SwiftUITests",
             dependencies: ["Camera-SwiftUI"]),

--- a/Sources/Camera-SwiftUI/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Camera-SwiftUI/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict><key>NSPrivacyCollectedDataTypes</key><array></array>
+	</dict>
+</plist>

--- a/Sources/Camera-SwiftUI/Service/CameraService.swift
+++ b/Sources/Camera-SwiftUI/Service/CameraService.swift
@@ -462,7 +462,15 @@ public class CameraService: NSObject, Identifiable {
             }
         }
     }
-    
+
+    public var minAvailableVideoZoomFactor: CGFloat {
+        videoDeviceInput.device.minAvailableVideoZoomFactor
+    }
+
+    public var maxAvailableVideoZoomFactor: CGFloat {
+        videoDeviceInput.device.maxAvailableVideoZoomFactor
+    }
+
     public func set(zoom: CGFloat){
         let factor = zoom < 1 ? 1 : zoom
         let device = self.videoDeviceInput.device

--- a/Sources/Camera-SwiftUI/Service/CameraService.swift
+++ b/Sources/Camera-SwiftUI/Service/CameraService.swift
@@ -484,7 +484,21 @@ public class CameraService: NSObject, Identifiable {
             print(error.localizedDescription)
         }
     }
-    
+
+    public func ramp(toZoom zoom: CGFloat, withRate rate: Float) {
+        let factor = zoom < 1 ? 1 : zoom
+        let device = self.videoDeviceInput.device
+
+        do {
+            try device.lockForConfiguration()
+            device.ramp(toVideoZoomFactor: factor, withRate: rate)
+            device.unlockForConfiguration()
+        }
+        catch {
+            print(error.localizedDescription)
+        }
+    }
+
     //    MARK: Capture Photo
     
     /// - Tag: CapturePhoto

--- a/Sources/Camera-SwiftUI/View/CameraPreview.swift
+++ b/Sources/Camera-SwiftUI/View/CameraPreview.swift
@@ -64,9 +64,11 @@ public struct CameraPreview: UIViewRepresentable {
     }
     
     public let session: AVCaptureSession
-    
-    public init(session: AVCaptureSession) {
+    public let videoGravity: AVLayerVideoGravity
+
+    public init(session: AVCaptureSession, videoGravity: AVLayerVideoGravity = .resizeAspect) {
         self.session = session
+        self.videoGravity = videoGravity
     }
     
     public func makeUIView(context: Context) -> VideoPreviewView {
@@ -75,6 +77,7 @@ public struct CameraPreview: UIViewRepresentable {
         viewFinder.videoPreviewLayer.cornerRadius = 0
         viewFinder.videoPreviewLayer.session = session
         viewFinder.videoPreviewLayer.connection?.videoOrientation = .portrait
+        viewFinder.videoPreviewLayer.videoGravity = videoGravity
         return viewFinder
     }
     


### PR DESCRIPTION
This fixes https://github.com/rorodriguez116/Camera-SwiftUI/issues/8, by overriding `videoGravity` to fill the available space:
```swift
CameraPreview(session: model.service.session, videoGravity: .resizeAspectFill)
```

Also adds privacy manifest required by Apple.